### PR TITLE
Fix ChevronDownIcon using fragment

### DIFF
--- a/expo-app/components/ui/icon/index.tsx
+++ b/expo-app/components/ui/icon/index.tsx
@@ -444,14 +444,14 @@ const ChevronDownIcon = createIcon({
   Root: Svg,
   viewBox: '0 0 24 24',
   path: (
-    <>
-      <Path
-        d="M6 9L12 15L18 9"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </>
+    <Path
+      d="M6 9L12 15L18 9"
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
   ),
 });
 


### PR DESCRIPTION
Fixes Issue #49 

Doesn't look the best, but no more errors + we moving away from gluestack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the appearance of the Chevron Down icon for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->